### PR TITLE
Frontend Slick Style Override

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -51,14 +51,21 @@ class Carousel_Slider_Block {
      */
     public static function render_carousel( $attributes, $content ) {
         if ( ! is_admin() ) {
-			wp_enqueue_style(
+            wp_enqueue_style(
                 'carousel-block-slick-style',
                 plugins_url( '/vendor/slick/slick.min.css', __FILE__ ),
                 [],
                 self::VERSION,
                 false
             );
-             wp_enqueue_script(
+            wp_enqueue_style(
+                'carousel-block-style',
+                plugins_url( '/build/style-index.css', __FILE__ ),
+                [],
+                self::VERSION,
+                false
+            );
+            wp_enqueue_script(
                 'carousel-block-slick-script',
                 plugins_url( '/vendor/slick/slick.min.js', __FILE__ ),
                 ['jquery'],


### PR DESCRIPTION
This pull request includes a small change to the `plugin.php` file. The change involves adding a new `wp_enqueue_style` call to load a CSS file for the carousel block. This to ensure that style.scsss styles are added frontend and override default Slick styles.

Also see issue https://github.com/imagewize/carousel-block/issues/1

* [`plugin.php`](diffhunk://#diff-63e630aa779572c3d4c2bc7edf2dc6ae2da5e6719b1495ab2682fdc983bc2d96R61-R67): Added `wp_enqueue_style` to load `carousel-block-style` with the path to `style-index.css`.