### PR TITLE
Slide and Responsive Settings Update

### DIFF
--- a/src/carousel/block.json
+++ b/src/carousel/block.json
@@ -37,7 +37,7 @@
     },
     "speed": {
       "type": "number",
-      "default": 500
+      "default": 300
     },
     "rtl": {
       "type": "boolean",
@@ -54,6 +54,18 @@
     "responsiveSlidesToScroll": {
       "type": "number",
       "default": 1
+    },
+    "slides": {
+      "type": "number",
+      "default": 4
+    },
+    "scrollGroup": {
+      "type": "boolean",
+      "default": false
+    },
+    "slidePadding": {
+      "type": "boolean",
+      "default": true
     }
   },
   "supports": {

--- a/src/carousel/edit.js
+++ b/src/carousel/edit.js
@@ -23,6 +23,9 @@ export default function Edit({ attributes, setAttributes, clientId }) {
         responsiveWidth,
         responsiveSlides,
         responsiveSlidesToScroll,
+        slides,
+        scrollGroup,
+        slidePadding,
     } = attributes;
 
     const slideCount = useSelect(
@@ -32,6 +35,8 @@ export default function Edit({ attributes, setAttributes, clientId }) {
     const blockProps = useBlockProps({
         className: classnames(
             `cb-shows-${slidesToShow}-slides`,
+            `cb-responsive-${responsiveSlides}-slides`,
+            { 'cb-padding': slidePadding },
             slideCount + 1 > slidesToShow ? 'cb-show-scrollbar' : 'cb-hide-scrollbar'
         ),
     });
@@ -102,6 +107,23 @@ export default function Edit({ attributes, setAttributes, clientId }) {
                         label={__('RTL Mode', 'cb')}
                         checked={rtl}
                         onChange={(value) => setAttributes({ rtl: value })}
+                    />
+                    <RangeControl
+                        label={__('Total Slides', 'cb')}
+                        value={slides}
+                        onChange={(value) => setAttributes({ slides: value })}
+                        min={1}
+                        max={20}
+                    />
+                    <ToggleControl
+                        label={__('Enable Scroll Group', 'cb')}
+                        checked={scrollGroup}
+                        onChange={(value) => setAttributes({ scrollGroup: value })}
+                    />
+                    <ToggleControl
+                        label={__('Enable Slide Padding', 'cb')}
+                        checked={slidePadding}
+                        onChange={(value) => setAttributes({ slidePadding: value })}
                     />
                 </PanelBody>
                 <PanelBody title={__('Responsive Settings', 'cb')} initialOpen={false}>

--- a/src/carousel/save.js
+++ b/src/carousel/save.js
@@ -1,4 +1,5 @@
 import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
+import classnames from 'classnames';
 
 export default function save({ attributes }) {
     const {
@@ -10,7 +11,12 @@ export default function save({ attributes }) {
         autoplay,
         autoplaySpeed,
         speed,
-        rtl
+        rtl,
+        responsiveWidth,
+        responsiveSlides,
+        responsiveSlidesToScroll,
+        slidePadding,
+        scrollGroup
     } = attributes;
 
     const slickSettings = {
@@ -21,11 +27,23 @@ export default function save({ attributes }) {
         infinite,
         autoplay,
         autoplaySpeed: parseInt(autoplaySpeed),
-        speed: parseInt(speed)
+        speed: parseInt(speed),
+        rtl,
+        responsive: [{
+            breakpoint: parseInt(responsiveWidth) + 1,
+            settings: {
+                slidesToShow: parseInt(responsiveSlides),
+                slidesToScroll: parseInt(responsiveSlidesToScroll)
+            }
+        }]
     };
 
     const blockProps = useBlockProps.save({
-        className: 'slick-slider',
+        className: classnames(
+            'slick-slider',
+            { 'cb-single-slide': slidesToShow === 1 },
+            { 'cb-padding': slidePadding }
+        ),
         'data-slick': JSON.stringify(slickSettings),
         dir: rtl ? 'rtl' : undefined
     });


### PR DESCRIPTION
This pull request includes several changes to the `carousel` component to add new features and improve its configurability. The most important changes include updates to the component's attributes, the addition of new controls in the edit interface, and adjustments to the save function to handle these new attributes.

### Updates to component attributes:
* [`src/carousel/block.json`](diffhunk://#diff-00af2fbae73e318d5ff84e3a49bb753397c2f27db910677778d645bf2e53d477L40-R40): Added new attributes `slides`, `scrollGroup`, and `slidePadding` with default values. Updated the `speed` attribute default value from 500 to 300. [[1]](diffhunk://#diff-00af2fbae73e318d5ff84e3a49bb753397c2f27db910677778d645bf2e53d477L40-R40) [[2]](diffhunk://#diff-00af2fbae73e318d5ff84e3a49bb753397c2f27db910677778d645bf2e53d477R57-R68)

### Addition of new controls in the edit interface:
* [`src/carousel/edit.js`](diffhunk://#diff-853556de8c70a8c1570c960bead889f0ed4be27e3cc7100ab1597f28bc71a0d1R26-R28): Updated the destructuring of attributes to include `slides`, `scrollGroup`, and `slidePadding`. Added corresponding controls (`RangeControl` and `ToggleControl`) for these attributes in the panel body. [[1]](diffhunk://#diff-853556de8c70a8c1570c960bead889f0ed4be27e3cc7100ab1597f28bc71a0d1R26-R28) [[2]](diffhunk://#diff-853556de8c70a8c1570c960bead889f0ed4be27e3cc7100ab1597f28bc71a0d1R111-R127)

### Adjustments to the save function:
* [`src/carousel/save.js`](diffhunk://#diff-259991ae1a9a1eb55927525416dc5ebd42a4414dfe8666f5bceabbb61e82f819R2): Imported `classnames` and updated the destructuring of attributes to include `responsiveWidth`, `responsiveSlides`, `responsiveSlidesToScroll`, `slidePadding`, and `scrollGroup`. Modified the `slickSettings` and `blockProps` to incorporate these new attributes and settings. [[1]](diffhunk://#diff-259991ae1a9a1eb55927525416dc5ebd42a4414dfe8666f5bceabbb61e82f819R2) [[2]](diffhunk://#diff-259991ae1a9a1eb55927525416dc5ebd42a4414dfe8666f5bceabbb61e82f819L13-R19) [[3]](diffhunk://#diff-259991ae1a9a1eb55927525416dc5ebd42a4414dfe8666f5bceabbb61e82f819L24-R46)