### PR TITLE
Plugin Details Update

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -1,10 +1,11 @@
 <?php
 /**
- * Plugin Name: Carousel Slider Block
+ * Plugin Name: Slick Carousel Block
  * Plugin URI: https://github.com/imagewize/carousel-block
  * Description: A responsive carousel slider block for Gutenberg. Add any blocks to slides.
  * Author URI: https://imagewize.com
  * Version: 1.0.16
+ * Author: Imagewize
  * License: GPL2+
  * License URI: https://www.gnu.org/licenses/gpl-2.0.txt
  *

--- a/plugin.php
+++ b/plugin.php
@@ -1,9 +1,9 @@
 <?php
 /**
  * Plugin Name: Carousel Slider Block
- * Plugin URI: https://wordpress.org/plugins/carousel-block
+ * Plugin URI: https://github.com/imagewize/carousel-block
  * Description: A responsive carousel slider block for Gutenberg. Add any blocks to slides.
- * Author URI: http://virgiliudiaconu.com/
+ * Author URI: https://imagewize.com
  * Version: 1.0.16
  * License: GPL2+
  * License URI: https://www.gnu.org/licenses/gpl-2.0.txt

--- a/plugin.php
+++ b/plugin.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Plugin Name: Slick Carousel Block
+ * Plugin Name: Creative Carousel Block
  * Plugin URI: https://github.com/imagewize/carousel-block
  * Description: A responsive carousel slider block for Gutenberg. Add any blocks to slides.
  * Author URI: https://imagewize.com


### PR DESCRIPTION
This pull request includes changes to the plugin metadata in the `plugin.php` file. The changes update the plugin name, plugin URI, author URI, and author information.

Metadata updates:

* Changed the plugin name from "Carousel Slider Block" to "Creative Carousel Block".
* Updated the plugin URI to point to the GitHub repository instead of the WordPress plugins page.
* Changed the author URI to "https://imagewize.com".
* Added "Imagewize" as the author.