### PR TITLE
Use Inline CSS Only for Carousel Block

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -69,13 +69,6 @@ class Carousel_Slider_Block {
                 self::VERSION,
                 false
             );
-            wp_enqueue_style(
-                'carousel-block-style',
-                plugins_url( '/build/carousel/style-index.css', __FILE__ ),
-                [],
-                self::VERSION,
-                false
-            );
             wp_enqueue_script(
                 'carousel-block-slick-script',
                 plugins_url( '/vendor/slick/slick.min.js', __FILE__ ),


### PR DESCRIPTION
This pull request includes a change to the `render_carousel` function in the `plugin.php` file. The change removes the enqueuing of the `carousel-block-style` stylesheet. This as we should be fine using inline CSS only.

Codebase simplification:

* [`plugin.php`](diffhunk://#diff-63e630aa779572c3d4c2bc7edf2dc6ae2da5e6719b1495ab2682fdc983bc2d96L72-L78): Removed the call to `wp_enqueue_style` for `carousel-block-style`, which enqueued the `style-index.css` file.