### PR TITLE
Composer Author Details

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,13 @@
     "description": "A responsive carousel slider block for WordPress Gutenberg editor",
     "type": "wordpress-plugin",
     "license": "GPL-2.0-or-later",
+    "authors": [
+        {
+            "name": "Jasper Frumau",
+            "email": "jasper@imagewize.com",
+            "homepage": "https://imagewize.com"
+        }
+    ],
     "keywords": [
         "wordpress",
         "plugin",


### PR DESCRIPTION
This pull request includes a small change to the `composer.json` file. The change adds author information for the plugin.

* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34R6-R12): Added author details including name, email, and homepage for Jasper Frumau.